### PR TITLE
Fixes issue with finding aapt2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,13 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.android.tools.build:gradle:3.2.0'
+    }
+    allprojects {
+        repositories {
+            google() // and here
+            jcenter()
+        }
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Tue Oct 16 01:00:28 EDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
Fixes `Could not find com.android.tools.build:aapt2:3.2.0-4818971.` error.  

Taken from [Android Studio 3.2 release notes](https://developer.android.com/studio/releases/):

> Beginning with Android Studio 3.2, the source for AAPT2 (Android Asset Packaging Tool 2) is Google's Maven repository.
To use AAPT2, make sure that you have a google() dependency in your build.gradle file as shown here: 
```
  buildscript {
      repositories {
          google() // here
          jcenter()
      }
      dependencies {
          classpath 'com.android.tools.build:gradle:3.2.0'
      }
  } allprojects {
      repositories {
          google() // and here
          jcenter()
  }
```